### PR TITLE
Add screen size extension for BuildContext

### DIFF
--- a/lib/extensions/utils.dart
+++ b/lib/extensions/utils.dart
@@ -1,0 +1,6 @@
+import 'package:flutter/material.dart';
+
+extension ScreenSizeExtension on BuildContext {
+  double get height => MediaQuery.of(this).size.height;
+  double get width => MediaQuery.of(this).size.width;
+}


### PR DESCRIPTION
## Generated with jules
This commit introduces a Dart extension to provide convenient access to screen height and width directly from the BuildContext.

The extension is defined in `lib/extensions/utils.dart` and allows developers to use `context.height` and `context.width` instead of the more verbose `MediaQuery.of(context).size.height` and `MediaQuery.of(context).size.width`.